### PR TITLE
Fix flag() with rest() support with no arg()

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,11 +175,6 @@ class Command {
     const visited = [c]
 
     while (bail === null) {
-      if (c._definedRest !== null && c.positionals.length === c._definedArgs.length) {
-        bail = c._onrest(p.rest())
-        break
-      }
-
       const n = p.next()
       if (n === null) break
 
@@ -201,6 +196,13 @@ class Command {
           visited.push(c)
           continue
         }
+      }
+
+      if (c._definedRest !== null && n.arg && c.positionals.length === c._definedArgs.length) {
+        // walk back parser index to include the current "arg"
+        p.i--
+        bail = c._onrest(p.rest())
+        break
       }
 
       bail = c._onarg(n.arg)

--- a/test.js
+++ b/test.js
@@ -54,6 +54,28 @@ test('command with rest arguments', async (t) => {
   t.alike(cmd.rest, ['some', 'more'])
 })
 
+test('command with flags, rest arguments but no args', async (t) => {
+  const cmd = command('test', flag('-l', 'test flag'), rest('...rest', 'rest arguments'))
+  cmd.parse(['-l', 'val', 'some', 'more'])
+  t.plan(2)
+  t.ok(cmd.flags.l)
+  t.alike(cmd.rest, ['val', 'some', 'more'])
+})
+
+test('command with flags & rest arguments swallows flags after first rest arg', async (t) => {
+  const cmd = command(
+    'test',
+    flag('--flag', 'Test argument'),
+    flag('--other', 'Other Test argument'),
+    rest('...rest', 'rest arguments')
+  )
+  cmd.parse(['--flag', 'val', 'some', 'more', '--other'])
+  t.plan(3)
+  t.ok(cmd.flags.flag)
+  t.ok(!cmd.flags.other)
+  t.alike(cmd.rest, ['val', 'some', 'more', '--other'])
+})
+
 test('command with header', async (t) => {
   const hd = 'Test command header'
   const cmd = command('test', header(hd))


### PR DESCRIPTION
Rest was triggered when all defined arguments were set, but in a scenario where there are no defined arguments and only a `rest()` to vacuum up arguments flags were never processed even if they were first.

The Parser now attempts to parse first and if the command falls through to interpreting the result as an argument, then the check for the number of defined arguments found is run. This means the parser needs to be walked back one place as it has already processed the first argument of the rest at that point.

It is assumed that the first non-defined argument found is the start of the rest arguments and all remaining arguments belong to the rest. This means even valid flags after the first rest argument are considered rest arguments, not flags.