### PR TITLE
Log full stack in case of error during run

### DIFF
--- a/index.js
+++ b/index.js
@@ -718,7 +718,7 @@ function runSync (c) {
   try {
     c._runner({ args: c.args, flags: c.flags, positionals: c.positionals, rest: c.rest, indices: c.indices, command: c })
   } catch (err) {
-    c.bail(createBail(c, err.message, null, null, err))
+    c.bail(createBail(c, err.stack, null, null, err))
   }
 }
 
@@ -726,6 +726,6 @@ async function runAsync (c) {
   try {
     await c._runner({ args: c.args, flags: c.flags, positionals: c.positionals, rest: c.rest, indices: c.indices, command: c })
   } catch (err) {
-    c.bail(createBail(c, err.message, null, null, err))
+    c.bail(createBail(c, err.stack, null, null, err))
   }
 }


### PR DESCRIPTION
Current behaviour in case of an error during the run is to print the paparam trace, but not the error's trace (only the error message), thereby complicating debugging.

Example:

```
const { command } = require('.')

function funcWhichThrows () {
  throw new Error('I throw')
}

const run = command('test', () => {
  funcWhichThrows()
})

run.parse()
```

Previously it would print a paparam stack trace without info about the actual error (except for the message)

```
/home/hans/holepunch/paparam/index.js:492
    throw new Error(bail.reason)
          ^

Error: I throw
    at Command._bail (/home/hans/holepunch/paparam/index.js:492:11)
    at Command.bail (/home/hans/holepunch/paparam/index.js:125:36)
    at runAsync (/home/hans/holepunch/paparam/index.js:729:7)
    at Command.parse (/home/hans/holepunch/paparam/index.js:228:26)
    at Object.<anonymous> (/home/hans/holepunch/paparam/qt.js:11:5)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    ```

With the change, the stack trace starts with the actual trace of the error

```
/home/hans/holepunch/paparam/index.js:492
    throw new Error(bail.reason)
          ^

Error: Error: I throw
    at funcWhichThrows (/home/hans/holepunch/paparam/qt.js:4:9)
    at Command._runner (/home/hans/holepunch/paparam/qt.js:8:3)
    at runAsync (/home/hans/holepunch/paparam/index.js:727:13)
    at Command.parse (/home/hans/holepunch/paparam/index.js:228:26)
    at Object.<anonymous> (/home/hans/holepunch/paparam/qt.js:11:5)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at Command._bail (/home/hans/holepunch/paparam/index.js:492:11)
    at Command.bail (/home/hans/holepunch/paparam/index.js:125:36)
    at runAsync (/home/hans/holepunch/paparam/index.js:729:7)
    at Command.parse (/home/hans/holepunch/paparam/index.js:228:26)
    at Object.<anonymous> (/home/hans/holepunch/paparam/qt.js:11:5)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
```
