### PR TITLE
Align `MISSING_ARG` with `UNKNOWN_ARG`

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ class Command {
 
     if (!bail) {
       const missing = this._definedArgs.filter((arg) => !arg.optional && !(arg.name in c.args))
-      if (missing.length > 0) bail = createBail(this, 'MISSING_ARGUMENT', null, { value: missing[0].help })
+      if (missing.length > 0) bail = createBail(this, 'MISSING_ARG', null, { value: missing[0].help })
     }
 
     if (!bail) {

--- a/test.js
+++ b/test.js
@@ -145,15 +145,15 @@ test('command with <required> argument', async (t) => {
 test('command with <required> arg but omitted', (t) => {
   t.plan(2)
   const cmd = command('test', flag('-l', 'test flag'), arg('<arg>', 'Test argument'))
-  t.exception(() => cmd.parse([]), /MISSING_ARGUMENT: <arg>/)
-  t.exception(() => cmd.parse(['-l']), /MISSING_ARGUMENT: <arg>/)
+  t.exception(() => cmd.parse([]), /MISSING_ARG: <arg>/)
+  t.exception(() => cmd.parse(['-l']), /MISSING_ARG: <arg>/)
 })
 
 test('command with [optional] arg and <required> arg but omitted', (t) => {
   t.plan(2)
   const cmd = command('test', flag('-l', 'test flag'), arg('[opt]', 'optional arg'), arg('<arg>', 'Test argument'))
-  t.exception(() => cmd.parse(['opt']), /MISSING_ARGUMENT: <arg>/)
-  t.exception(() => cmd.parse(['-l']), /MISSING_ARGUMENT: <arg>/)
+  t.exception(() => cmd.parse(['opt']), /MISSING_ARG: <arg>/)
+  t.exception(() => cmd.parse(['-l']), /MISSING_ARG: <arg>/)
 })
 
 test('command with [optional] arg that is omitted', (t) => {


### PR DESCRIPTION
`UNKNOWN_ARG` set the precedent so I've changed the previous `MISSING_ARGUMENT` to `MISSING_ARG` to align.