### PR TITLE
fix help output showing `[object Object]`

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,8 @@ class Command {
 
     if (this.header) s += this.header + EOL + EOL
     this._indent = this.header ? '  ' : ''
-    s += this.usage(...args)
+    const output = this.usage(...args)
+    s += typeof output === 'string' ? output : ''
     this._indent = ''
 
     if (this.footer) s += EOL + (Object.hasOwn(this.footer, 'help') ? this.footer.help : this.footer) + EOL


### PR DESCRIPTION
`$ pear help foobar`


---

before

<img width="395" height="120" alt="image" src="https://github.com/user-attachments/assets/907f078e-db94-4514-af86-df5e41d0aa8e" />

after

<img width="374" height="120" alt="image" src="https://github.com/user-attachments/assets/4ad0ef64-b8d2-4f7c-8065-92b7aaa1f961" />
