### PR TITLE
help --json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Update command with additional modifiers & subcommands. A runner function may al
 
 #### `cmd.parse(argv = process.argv.slice(2), opts)`
 
-Parses an array of command line arguments and executes the command based on the provided definition. Automatically handles '--help' or '-h' flags to display help information, use `help --json` for structured output.
+Parses an array of command line arguments and executes the command based on the provided definition. Automatically handles '--help' or '-h' flags to display help information.
 
 - **Arguments**:
   - `argv` `<String[]>`: An array of strings representing the command line arguments. Defaults to program arguments `process.argv.slice(2)` if unspecified. If the `-h` or `--help` flag is supplied help for the related command will be shown.
@@ -165,6 +165,10 @@ Parses an array of command line arguments and executes the command based on the 
     - `bails` `<Boolean>`: If false, suppresses parse errors from being passed to the command bail handler and returns `null` instead. Default `true`.
 - **Returns**:
   - `null` if the parsing leads to an error (with an error output) or the command object if the command executes without errors.
+
+##### `help --json`
+
+Outputs structured help as JSON when a `help` command is defined.
 
 #### `cmd.help(...subcommands)`
 

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ Parses an array of command line arguments and executes the command based on the 
 - **Returns**:
   - `null` if the parsing leads to an error (with an error output) or the command object if the command executes without errors.
 
-##### `help --json`
+#### `help --json`
 
-Outputs structured help as JSON when a `help` command is defined.
+Prints structured command help as JSON.
 
 #### `cmd.help(...subcommands)`
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Update command with additional modifiers & subcommands. A runner function may al
 
 #### `cmd.parse(argv = process.argv.slice(2), opts)`
 
-Parses an array of command line arguments and executes the command based on the provided definition. Automatically handles '--help' or '-h' flags to display help information.
+Parses an array of command line arguments and executes the command based on the provided definition. Automatically handles '--help' or '-h' flags to display help information, use `help --json` for structured output.
 
 - **Arguments**:
   - `argv` `<String[]>`: An array of strings representing the command line arguments. Defaults to program arguments `process.argv.slice(2)` if unspecified. If the `-h` or `--help` flag is supplied help for the related command will be shown.

--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ class Command {
     return s
   }
 
-  _json() {
+  toJSON() {
     const json = {
       name: this.name,
       summary: this.summary,
@@ -186,15 +186,29 @@ class Command {
       commands: {}
     }
     for (const arg of this._definedArgs) {
-      if (!arg.hidden) json.args[arg.help] = arg.description
+      json.args[arg.help] = arg.description
     }
     if (this._definedRest) json.args[this._definedRest.help] = this._definedRest.description
     for (const flag of this._definedFlags.values()) {
-      if (!flag.hidden) json.flags[flag.help] = flag.description
+      json.flags[flag.help] = flag.description
     }
     for (const [name, command] of this._definedCommands) {
-      if (command.hidden) continue
-      json.commands[name] = command._json()
+      json.commands[name] = command.toJSON()
+    }
+    return json
+  }
+
+  helpJSON() {
+    const json = this.toJSON()
+    for (const arg of this._definedArgs) {
+      if (arg.hidden) delete json.args[arg.help]
+    }
+    for (const flag of this._definedFlags.values()) {
+      if (flag.hidden) delete json.flags[flag.help]
+    }
+    for (const [name, command] of this._definedCommands) {
+      if (command.hidden) delete json.commands[name]
+      else json.commands[name] = command.helpJSON()
     }
     return json
   }
@@ -215,8 +229,8 @@ class Command {
 
   parse(input = argv(), opts = { run: true }) {
     const { sync = false, bails = true } = opts
-    const json = input.includes('--json') && this._getCommand(input[0])?.name === 'help'
-    if (json) {
+    const isHelpJSON = input.includes('--json') && this._getCommand(input[0])?.name === 'help'
+    if (isHelpJSON) {
       input = input.slice(1).filter((arg) => arg !== '--json')
       input.push('--help')
     }
@@ -281,7 +295,7 @@ class Command {
     if (!bail) {
       if (c.flags.help) {
         if (!opts.silent) {
-          const help = json ? JSON.stringify(c._json()) : c.help()
+          const help = isHelpJSON ? JSON.stringify(c.helpJSON()) : c.help()
           console.log(help)
         }
         return null

--- a/index.js
+++ b/index.js
@@ -281,9 +281,7 @@ class Command {
     if (!bail) {
       if (c.flags.help) {
         if (!opts.silent) {
-          const flatten = (_, value) =>
-            typeof value === 'string' ? value.replace(/\n/g, ' ') : value
-          const help = json ? JSON.stringify(c._json(), flatten) : c.help()
+          const help = json ? JSON.stringify(c._json()) : c.help()
           console.log(help)
         }
         return null

--- a/index.js
+++ b/index.js
@@ -281,9 +281,9 @@ class Command {
     if (!bail) {
       if (c.flags.help) {
         if (!opts.silent) {
-          const trim = (_, value) =>
-            typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : value
-          const help = json ? JSON.stringify(c._json(), trim) : c.help()
+          const flatten = (_, value) =>
+            typeof value === 'string' ? value.replace(/\n/g, ' ') : value
+          const help = json ? JSON.stringify(c._json(), flatten) : c.help()
           console.log(help)
         }
         return null

--- a/index.js
+++ b/index.js
@@ -281,11 +281,9 @@ class Command {
     if (!bail) {
       if (c.flags.help) {
         if (!opts.silent) {
-          const help = json
-            ? JSON.stringify(c._json(), (_, value) =>
-                typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : value
-              )
-            : c.help()
+          const trim = (_, value) =>
+            typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : value
+          const help = json ? JSON.stringify(c._json(), trim) : c.help()
           console.log(help)
         }
         return null

--- a/index.js
+++ b/index.js
@@ -176,6 +176,29 @@ class Command {
     return s
   }
 
+  _json() {
+    const json = {
+      name: this.name,
+      summary: this.summary,
+      description: this.description,
+      args: {},
+      flags: {},
+      commands: {}
+    }
+    for (const arg of this._definedArgs) {
+      if (!arg.hidden) json.args[arg.help] = arg.description
+    }
+    if (this._definedRest) json.args[this._definedRest.help] = this._definedRest.description
+    for (const flag of this._definedFlags.values()) {
+      if (!flag.hidden) json.flags[flag.help] = flag.description
+    }
+    for (const [name, command] of this._definedCommands) {
+      if (command.hidden) continue
+      json.commands[name] = command._json()
+    }
+    return json
+  }
+
   usage(subcommand, ...args) {
     if (subcommand) {
       const sub = this._definedCommands.get(subcommand)
@@ -192,6 +215,11 @@ class Command {
 
   parse(input = argv(), opts = { run: true }) {
     const { sync = false, bails = true } = opts
+    const json = input.includes('--json') && this._getCommand(input[0])?.name === 'help'
+    if (json) {
+      input = input.slice(1).filter((arg) => arg !== '--json')
+      input.push('--help')
+    }
     const p = new Parser(input)
 
     let c = this._reset()
@@ -252,7 +280,14 @@ class Command {
 
     if (!bail) {
       if (c.flags.help) {
-        if (!opts.silent) console.log(c.help())
+        if (!opts.silent) {
+          const help = json
+            ? JSON.stringify(c._json(), (_, value) =>
+                typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : value
+              )
+            : c.help()
+          console.log(help)
+        }
         return null
       }
       for (const v of c._validators) {

--- a/test.js
+++ b/test.js
@@ -1240,24 +1240,7 @@ test('help --json outputs flags and commands', (t) => {
     ),
     command('help')
   )
-  const expected = `pear stage [flags] <link> [command]
-
-stage pear app
-
-more info
-about staging pear app
-
-Arguments:
-  <link>         App link key
-
-Flags:
-  --dry-run|-d   View the changes without applying them
-  --help|-h      Show help
-
-Commands:
-  run            Run app
-`
-  const expectedJson = {
+  const expected = {
     name: 'stage',
     summary: 'stage pear app',
     description: 'more info about staging pear app',
@@ -1277,15 +1260,10 @@ Commands:
       }
     }
   }
-  t.plan(2)
+  t.plan(1)
   const { log } = console
   console.log = (help) => {
-    t.is(help, expected)
-    console.log = log
-  }
-  cmd.parse(['stage', '--help'])
-  console.log = (help) => {
-    t.alike(JSON.parse(help), expectedJson)
+    t.alike(JSON.parse(help), expected)
     console.log = log
   }
   cmd.parse(['help', '--json', 'stage'])

--- a/test.js
+++ b/test.js
@@ -1243,7 +1243,7 @@ test('help --json outputs flags and commands', (t) => {
   const expected = {
     name: 'stage',
     summary: 'stage pear app',
-    description: 'more info about staging pear app',
+    description: 'more info\nabout staging pear app',
     args: { '<link>': 'App link key' },
     flags: {
       '--dry-run|-d': 'View the changes without applying them',

--- a/test.js
+++ b/test.js
@@ -1235,8 +1235,11 @@ test('help --json outputs flags and commands', (t) => {
       summary('stage pear app'),
       description('more info\nabout staging pear app'),
       arg('<link>', 'App link key'),
+      arg('[hidden]', 'Hidden arg').hide(),
       flag('--dry-run|-d', 'View the changes without applying them'),
-      command('run', summary('Run app'))
+      flag('--hidden', 'Hidden flag').hide(),
+      command('run', summary('Run app')),
+      command('hidden', summary('Hidden command')).hide()
     ),
     command('help')
   )
@@ -1260,7 +1263,11 @@ test('help --json outputs flags and commands', (t) => {
       }
     }
   }
-  t.plan(1)
+  t.plan(4)
+  const json = cmd.toJSON().commands.stage
+  t.is(json.args['[hidden]'], 'Hidden arg')
+  t.is(json.flags['--hidden'], 'Hidden flag')
+  t.is(json.commands.hidden.summary, 'Hidden command')
   const { log } = console
   console.log = (help) => {
     t.alike(JSON.parse(help), expected)

--- a/test.js
+++ b/test.js
@@ -1216,6 +1216,81 @@ test('auto --help|-h support', async (t) => {
   t.is(cmd.parse(['--help']), null)
 })
 
+test('help --json support', (t) => {
+  const cmd = command('test', command('help'))
+  t.plan(1)
+  const { log } = console
+  console.log = (help) => {
+    t.is(JSON.parse(help).name, 'test')
+    console.log = log
+  }
+  cmd.parse(['help', '--json'])
+})
+
+test('help --json outputs flags and commands', (t) => {
+  const cmd = command(
+    'pear',
+    command(
+      'stage',
+      summary('stage pear app'),
+      description('more info\nabout staging pear app'),
+      arg('<link>', 'App link key'),
+      flag('--dry-run|-d', 'View the changes without applying them'),
+      command('run', summary('Run app'))
+    ),
+    command('help')
+  )
+  const expected = `pear stage [flags] <link> [command]
+
+stage pear app
+
+more info
+about staging pear app
+
+Arguments:
+  <link>         App link key
+
+Flags:
+  --dry-run|-d   View the changes without applying them
+  --help|-h      Show help
+
+Commands:
+  run            Run app
+`
+  const expectedJson = {
+    name: 'stage',
+    summary: 'stage pear app',
+    description: 'more info about staging pear app',
+    args: { '<link>': 'App link key' },
+    flags: {
+      '--dry-run|-d': 'View the changes without applying them',
+      '--help|-h': 'Show help'
+    },
+    commands: {
+      run: {
+        name: 'run',
+        summary: 'Run app',
+        description: '',
+        args: {},
+        flags: { '--help|-h': 'Show help' },
+        commands: {}
+      }
+    }
+  }
+  t.plan(2)
+  const { log } = console
+  console.log = (help) => {
+    t.is(help, expected)
+    console.log = log
+  }
+  cmd.parse(['stage', '--help'])
+  console.log = (help) => {
+    t.alike(JSON.parse(help), expectedJson)
+    console.log = log
+  }
+  cmd.parse(['help', '--json', 'stage'])
+})
+
 test('parse - silent option', async (t) => {
   t.plan(0)
   const cmd = command('test')


### PR DESCRIPTION
`pear seed` example:

### help --json

<img width="1343" height="380" alt="image" src="https://github.com/user-attachments/assets/544fe33f-9029-4eb1-bd5e-4e5a97a528a8" />


### help (default, to compare)

<img width="1100" height="546" alt="image" src="https://github.com/user-attachments/assets/32cf439d-64ca-48c0-a02c-149d0c2ced45" />


---

### entire "pear help --json` output

```bash
➜  pear git:(main) ./pear.dev help --json | jq
{
  "name": "pear",
  "summary": "",
  "description": "",
  "args": {},
  "flags": {
    "-v": "Print version",
    "--log-level|-L <level>": "Verbosity to log at — 0=off, 1=error, 2=info, or 3=trace",
    "--help|-h": "Show help"
  },
............
```
